### PR TITLE
build*.sh: Add support for using system clang

### DIFF
--- a/build-kernels-clang.sh
+++ b/build-kernels-clang.sh
@@ -6,7 +6,10 @@ CLANG_A11=$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r353983c/bin/
 CLANG_A12=$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r416183b/bin/
 CLANG_A13=$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r450784d/bin/
 
-if  [ -d "$CLANG_A13" ]; then
+if [ "$use_system_clang" = true ]; then
+    echo "Using system Clang (build $(clang --version | head -n1 | awk '{print $3}'))."
+    export CLANG=/usr/bin/
+elif  [ -d "$CLANG_A13" ]; then
     echo "Using Clang (build r450784d) from Android 13."
     export CLANG=$CLANG_A13
 elif  [ -d "$CLANG_A12" ]; then

--- a/build_shared.sh
+++ b/build_shared.sh
@@ -13,10 +13,18 @@ echo "ANDROID_ROOT: ${ANDROID_ROOT}"
 echo "KERNEL_TOP  : ${KERNEL_TOP}"
 echo "KERNEL_TMP  : ${KERNEL_TMP}"
 
+if [ "$use_system_clang" = true ] ; then
+    CROSS_COMPILE="aarch64-linux-gnu-"
+    CROSS_COMPILE_ARM32="arm-none-eabi-"
+else
+    CROSS_COMPILE="aarch64-linux-android-"
+    CROSS_COMPILE_ARM32="arm-linux-androideabi-"
+fi
+
 BUILD_ARGS="${BUILD_ARGS} \
 ARCH=arm64 \
-CROSS_COMPILE=aarch64-linux-android- \
-CROSS_COMPILE_ARM32=arm-linux-androideabi- \
+CROSS_COMPILE=${CROSS_COMPILE} \
+CROSS_COMPILE_ARM32=${CROSS_COMPILE_ARM32} \
 -j$(nproc)"
 
 for platform in $PLATFORMS; do \

--- a/build_shared_vars.sh
+++ b/build_shared_vars.sh
@@ -15,21 +15,23 @@ find_repo_root()
 usage(){
     cat <<EOF
 Build kernel for supported devices
-Usage: ${0##*/} [-k -p <platform>]
+Usage: ${0##*/} [-k -p <platform> -s]
 
 Options:
 -k              keep kernel tmp after build
 -p <platform>   only build the kernel for <platform>
+-s              use system clang
 EOF
 }
 
 
-arguments=khp:
+arguments=khps:
 while getopts $arguments argument ; do
     case $argument in
         k) keep_kernel_tmp=t ;;
         p) only_build_for=$OPTARG;;
         h) usage; exit 0;;
+        s) use_system_clang=true;;
         ?) usage; exit 1;;
     esac
 done


### PR DESCRIPTION
-s has to come before -d foobar, as otherwise it seems to be treated as OPTARG.