### PR TITLE
[K.P.1.0] Unify kernel builds for the same platform

### DIFF
--- a/KernelConfig.mk
+++ b/KernelConfig.mk
@@ -16,15 +16,22 @@ BUILD_KERNEL := false
 
 ifeq ($(BUILD_KERNEL),false)
 
+PLATFORM_KERNEL_OUT := $(KERNEL_PATH)/common-kernel/$(PRODUCT_PLATFORM)
+
 ifeq ($(BOARD_INCLUDE_DTB_IN_BOOTIMG), true)
     # AOSP will concatenate all these into a single dtb.img
-    BOARD_PREBUILT_DTBIMAGE_DIR := $(KERNEL_PATH)/common-kernel/$(TARGET_DEVICE)/
+    BOARD_PREBUILT_DTBIMAGE_DIR := $(PLATFORM_KERNEL_OUT)/dtb/
 else
     dtb := "-dtb"
 endif
 
-LOCAL_KERNEL := $(KERNEL_PATH)/common-kernel/kernel$(dtb)-$(TARGET_DEVICE)
+ifeq ($(TARGET_NEEDS_DTBOIMAGE),true)
+    BOARD_PREBUILT_DTBOIMAGE := $(PLATFORM_KERNEL_OUT)/dtbo.img
+endif
+
+LOCAL_KERNEL := $(PLATFORM_KERNEL_OUT)/kernel$(dtb)
 
 PRODUCT_COPY_FILES += \
     $(LOCAL_KERNEL):kernel
+
 endif

--- a/build-kernels-clang.sh
+++ b/build-kernels-clang.sh
@@ -2,7 +2,6 @@
 
 . "${0%/*}/build_shared_vars.sh"
 
-
 CLANG_A11=$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r353983c/bin/
 CLANG_A12=$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r416183b/bin/
 CLANG_A13=$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r450784d/bin/
@@ -18,12 +17,8 @@ elif [ -d "$CLANG_A11" ]; then
     export CLANG=$CLANG_A11
 fi
 
-# Cross Compiler
-CC="clang"
-
 # Build command
-BUILD_ARGS="LLVM=1 LLVM_IAS=1"
-
+BUILD_ARGS="LLVM=1 LLVM_IAS=1 CC=clang"
 
 PATH=$CLANG:$PATH
 # source shared parts

--- a/build_shared.sh
+++ b/build_shared.sh
@@ -13,64 +13,63 @@ echo "ANDROID_ROOT: ${ANDROID_ROOT}"
 echo "KERNEL_TOP  : ${KERNEL_TOP}"
 echo "KERNEL_TMP  : ${KERNEL_TMP}"
 
+BUILD_ARGS="${BUILD_ARGS} \
+ARCH=arm64 \
+CROSS_COMPILE=aarch64-linux-android- \
+CROSS_COMPILE_ARM32=arm-linux-androideabi- \
+-j$(nproc)"
+
 for platform in $PLATFORMS; do \
 
     case $platform in
         nagara)
             DEVICE=$NAGARA
             COMPRESSED="false"
-            APENDED_DTB="false"
             DTBO="true"
             SOCDTB="waipio-v2.dtb"
             ;;
     esac
 
-    if [ $COMPRESSED = "true" ]; then
+    if [ "$COMPRESSED" = "true" ]; then
         comp=".gz"
     fi
-    if [ $APENDED_DTB = "true" ]; then
+    if [ ! "$SOCDTB" ]; then
         dtb="-dtb"
     fi
     for device in $DEVICE; do \
         (
             if [ ! $only_build_for ] || [ $device = $only_build_for ] ; then
 
-                KERNEL_TMP=$KERNEL_TMP-${device}
+                KERNEL_TMP_DEVICE=$KERNEL_TMP/${device}
                 # Keep kernel tmp when building for a specific device or when using keep tmp
-                [ ! "$keep_kernel_tmp" ] && [ ! "$only_build_for" ] && rm -rf "${KERNEL_TMP}"
-                mkdir -p "${KERNEL_TMP}"
+                [ ! "$keep_kernel_tmp" ] && [ ! "$only_build_for" ] && rm -rf "${KERNEL_TMP_DEVICE}"
+                mkdir -p "${KERNEL_TMP_DEVICE}"
+
+                BUILD_ARGS_DEVICE="$BUILD_ARGS O=$KERNEL_TMP_DEVICE"
 
                 # In case this is a dirty rebuild, delete all DTBs and DTBOs so that they
                 # won't be erraneously copied from a build for a different device/platform
-                find "$KERNEL_TMP/arch/arm64/boot/dts/{qcom,somc}/" \( -name *.dtb -o -name *.dtbo \) -delete 2>/dev/null || true
+                find "$KERNEL_TMP_DEVICE/arch/arm64/boot/dts/{qcom,somc}/" \( -name *.dtb -o -name *.dtbo \) -delete 2>/dev/null || true
 
                 echo "================================================="
                 echo "Platform -> ${platform} :: Device -> $device"
-                make O="$KERNEL_TMP" ARCH=arm64 \
-                     CROSS_COMPILE=aarch64-linux-android- \
-                     CROSS_COMPILE_ARM32=arm-linux-androideabi- \
-                     ${BUILD_ARGS} ${CC:+CC="${CC}"} -j$(nproc) \
-                     aosp_${platform}_${device}_defconfig
+                make $BUILD_ARGS_DEVICE aosp_${platform}_${device}_defconfig
 
                 echo "The build may take up to 10 minutes. Please be patient ..."
                 echo "Building new kernel image ..."
-                echo "Logging to $KERNEL_TMP/build.log"
-                make O="$KERNEL_TMP" ARCH=arm64 \
-                     CROSS_COMPILE=aarch64-linux-android- \
-                     CROSS_COMPILE_ARM32=arm-linux-androideabi- \
-                     ${BUILD_ARGS} ${CC:+CC="${CC}"} -j$(nproc) \
-                     >"$KERNEL_TMP"/build.log 2>&1;
+                echo "Logging to $KERNEL_TMP_DEVICE/build.log"
+                make $BUILD_ARGS_DEVICE >"$KERNEL_TMP_DEVICE"/build.log 2>&1;
 
                 echo "Copying new kernel image ..."
-                cp "$KERNEL_TMP/arch/arm64/boot/Image$comp$dtb" "$KERNEL_TOP/common-kernel/kernel$dtb-$device"
-                if [ $APENDED_DTB = "false" ]; then
+                cp "$KERNEL_TMP_DEVICE/arch/arm64/boot/Image$comp$dtb" "$KERNEL_TOP/common-kernel/kernel$dtb-$device"
+                if [ "$SOCDTB" ]; then
                     mkdir -p "$KERNEL_TOP/common-kernel/$device/"
-                    cp "$KERNEL_TMP/arch/arm64/boot/dts/qcom/$SOCDTB" "$KERNEL_TOP/common-kernel/$device/"
+                    cp "$KERNEL_TMP_DEVICE/arch/arm64/boot/dts/qcom/$SOCDTB" "$KERNEL_TOP/common-kernel/$device/"
                 fi
-                if [ $DTBO = "true" ]; then
+                if [ "$DTBO" = "true" ]; then
                     # shellcheck disable=SC2046
                     # note: We want wordsplitting in this case.
-                    $MKDTIMG create "$KERNEL_TOP"/common-kernel/dtbo-${device}.img $(find "$KERNEL_TMP"/arch/arm64/boot/dts/qcom/ -name "*.dtbo")
+                    $MKDTIMG create "$KERNEL_TOP"/common-kernel/dtbo-${device}.img $(find "$KERNEL_TMP_DEVICE"/arch/arm64/boot/dts/qcom/ -name "*.dtbo")
                 fi
 
             fi

--- a/build_shared.sh
+++ b/build_shared.sh
@@ -21,60 +21,61 @@ CROSS_COMPILE_ARM32=arm-linux-androideabi- \
 
 for platform in $PLATFORMS; do \
 
-    case $platform in
-        nagara)
-            DEVICE=$NAGARA
-            COMPRESSED="false"
-            DTBO="true"
-            SOCDTB="waipio-v2.dtb"
-            ;;
-    esac
+    if [ ! $only_build_for ] || [ $platform = $only_build_for ] ; then
 
-    if [ "$COMPRESSED" = "true" ]; then
-        comp=".gz"
+        case $platform in
+            nagara)
+                COMPRESSED="false"
+                DTBO="true"
+                SOCDTB="waipio-v2.dtb"
+                ;;
+        esac
+
+        if [ "$COMPRESSED" = "true" ]; then
+            comp=".gz"
+        fi
+        if [ ! "$SOCDTB" ]; then
+            dtb="-dtb"
+        fi
+
+        KERNEL_TMP_PLATFORM=$KERNEL_TMP/${platform}
+        BUILD_ARGS_PLATFORM="$BUILD_ARGS O=$KERNEL_TMP_PLATFORM"
+
+        # Keep kernel tmp when building for a specific platform or when using keep tmp
+        [ ! "$keep_kernel_tmp" ] && [ ! "$only_build_for" ] && rm -rf "${KERNEL_TMP_PLATFORM}"
+        mkdir -p "${KERNEL_TMP_PLATFORM}"
+
+        PLATFORM_KERNEL_OUT=$KERNEL_TOP/common-kernel/$platform
+        mkdir -p "$PLATFORM_KERNEL_OUT"
+
+        # In case this is a dirty rebuild, delete all DTBs and DTBOs so that they
+        # won't be erroneously copied from a build for a different platform
+        find "$KERNEL_TMP_PLATFORM/arch/arm64/boot/dts/{qcom,somc}/" \( -name *.dtb -o -name *.dtbo \) -delete 2>/dev/null || true
+
+        echo "================================================="
+        echo "Platform -> ${platform}"
+        make $BUILD_ARGS_PLATFORM aosp_${platform}_defconfig
+
+        echo "The build may take up to 10 minutes. Please be patient ..."
+        echo "Building new kernel image ..."
+        echo "Logging to $KERNEL_TMP_PLATFORM/build.log"
+        make $BUILD_ARGS_PLATFORM >"$KERNEL_TMP_PLATFORM/build.log" 2>&1;
+
+        echo "Copying new kernel image ..."
+        cp "$KERNEL_TMP_PLATFORM/arch/arm64/boot/Image$comp$dtb" "$PLATFORM_KERNEL_OUT/kernel$dtb"
+        if [ "$SOCDTB" ]; then
+            mkdir -p "$PLATFORM_KERNEL_OUT/dtb/"
+            cp "$KERNEL_TMP_PLATFORM/arch/arm64/boot/dts/qcom/$SOCDTB" "$PLATFORM_KERNEL_OUT/dtb/"
+        fi
+        if [ "$DTBO" = "true" ]; then
+            DTBO_OUT="$PLATFORM_KERNEL_OUT/dtbo.img"
+            echo "Creating $DTBO_OUT ..."
+            # shellcheck disable=SC2046
+            # note: We want wordsplitting in this case.
+            $MKDTIMG create $DTBO_OUT $(find "$KERNEL_TMP_PLATFORM/arch/arm64/boot/dts/qcom/" -name "*.dtbo")
+        fi
+
     fi
-    if [ ! "$SOCDTB" ]; then
-        dtb="-dtb"
-    fi
-    for device in $DEVICE; do \
-        (
-            if [ ! $only_build_for ] || [ $device = $only_build_for ] ; then
-
-                KERNEL_TMP_DEVICE=$KERNEL_TMP/${device}
-                # Keep kernel tmp when building for a specific device or when using keep tmp
-                [ ! "$keep_kernel_tmp" ] && [ ! "$only_build_for" ] && rm -rf "${KERNEL_TMP_DEVICE}"
-                mkdir -p "${KERNEL_TMP_DEVICE}"
-
-                BUILD_ARGS_DEVICE="$BUILD_ARGS O=$KERNEL_TMP_DEVICE"
-
-                # In case this is a dirty rebuild, delete all DTBs and DTBOs so that they
-                # won't be erraneously copied from a build for a different device/platform
-                find "$KERNEL_TMP_DEVICE/arch/arm64/boot/dts/{qcom,somc}/" \( -name *.dtb -o -name *.dtbo \) -delete 2>/dev/null || true
-
-                echo "================================================="
-                echo "Platform -> ${platform} :: Device -> $device"
-                make $BUILD_ARGS_DEVICE aosp_${platform}_${device}_defconfig
-
-                echo "The build may take up to 10 minutes. Please be patient ..."
-                echo "Building new kernel image ..."
-                echo "Logging to $KERNEL_TMP_DEVICE/build.log"
-                make $BUILD_ARGS_DEVICE >"$KERNEL_TMP_DEVICE"/build.log 2>&1;
-
-                echo "Copying new kernel image ..."
-                cp "$KERNEL_TMP_DEVICE/arch/arm64/boot/Image$comp$dtb" "$KERNEL_TOP/common-kernel/kernel$dtb-$device"
-                if [ "$SOCDTB" ]; then
-                    mkdir -p "$KERNEL_TOP/common-kernel/$device/"
-                    cp "$KERNEL_TMP_DEVICE/arch/arm64/boot/dts/qcom/$SOCDTB" "$KERNEL_TOP/common-kernel/$device/"
-                fi
-                if [ "$DTBO" = "true" ]; then
-                    # shellcheck disable=SC2046
-                    # note: We want wordsplitting in this case.
-                    $MKDTIMG create "$KERNEL_TOP"/common-kernel/dtbo-${device}.img $(find "$KERNEL_TMP_DEVICE"/arch/arm64/boot/dts/qcom/ -name "*.dtbo")
-                fi
-
-            fi
-        )
-    done
 done
 
 

--- a/build_shared_vars.sh
+++ b/build_shared_vars.sh
@@ -51,7 +51,8 @@ MKDTIMG=$ANDROID_ROOT/out/host/linux-x86/bin/mkdtimg
 
 KERNEL_TOP=$ANDROID_ROOT/kernel/sony/msm-5.10
 # $KERNEL_TMP sub dir per script
-KERNEL_TMP=$ANDROID_ROOT/out/${0##*-}/kernel-tmp
+c=${0##*-}
+KERNEL_TMP=$ANDROID_ROOT/out/kernel-5.10/${c%%.sh}
 
 export PATH=$PATH:$ANDROID_ROOT/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/bin
 export PATH=$PATH:$ANDROID_ROOT/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/bin

--- a/build_shared_vars.sh
+++ b/build_shared_vars.sh
@@ -15,20 +15,20 @@ find_repo_root()
 usage(){
     cat <<EOF
 Build kernel for supported devices
-Usage: ${0##*/} [-k -d <device>]
+Usage: ${0##*/} [-k -p <platform>]
 
 Options:
 -k              keep kernel tmp after build
--d <device>     only build the kernel for <device>
+-p <platform>   only build the kernel for <platform>
 EOF
 }
 
 
-arguments=khd:
+arguments=khp:
 while getopts $arguments argument ; do
     case $argument in
         k) keep_kernel_tmp=t ;;
-        d) only_build_for=$OPTARG;;
+        p) only_build_for=$OPTARG;;
         h) usage; exit 0;;
         ?) usage; exit 1;;
     esac
@@ -41,8 +41,6 @@ if [ -z "$ANDROID_BUILD_TOP" ]; then
 else
     ANDROID_ROOT="$ANDROID_BUILD_TOP"
 fi
-
-NAGARA="pdx223 pdx224"
 
 PLATFORMS="nagara"
 


### PR DESCRIPTION
The binaries for all devices in a platform (except their dtbo's, logically so) are identical and do not need to be built and stored separately to save on bloat and cognitive overhead.  Reduce the build to be invoked per-platform instead of per-device, following kernel changes that unified the defconfigs

Finally, resturcture the output folder structure to keep everything related to a single platform inside the same folder, instead of having various filename constructs.

https://github.com/sonyxperiadev/kernel/pull/2561
https://github.com/sonyxperiadev/kernel-defconfig/pull/128
https://github.com/sonyxperiadev/device-sony-pdx223/pull/8
https://github.com/sonyxperiadev/device-sony-pdx224/pull/4