### PR TITLE
[1.0.r1] Add support for Columbia platform

### DIFF
--- a/build_shared.sh
+++ b/build_shared.sh
@@ -31,6 +31,13 @@ for platform in $PLATFORMS; do \
                 SOCDTB="waipio-v2.dtb"
                 DEVICES="pdx223 pdx224"
                 ;;
+            columbia)
+                COMPRESSED="false"
+                DTBO="true"
+                SOC=parrot
+                SOCDTB="parrot.dtb"
+                DEVICES="pdx246"
+                ;;
         esac
 
         if [ "$COMPRESSED" = "true" ]; then

--- a/build_shared.sh
+++ b/build_shared.sh
@@ -40,7 +40,12 @@ for platform in $PLATFORMS; do \
             dtb="-dtb"
         fi
 
-        KERNEL_TMP_PLATFORM=$KERNEL_TMP/${platform}
+        # Don't override $KERNEL_TMP when set by manually
+        if [ ! "$build_directory" ] ; then
+            KERNEL_TMP_PLATFORM=$KERNEL_TMP/${platform}
+        else
+            KERNEL_TMP_PLATFORM=${build_directory}
+        fi
         BUILD_ARGS_PLATFORM="$BUILD_ARGS O=$KERNEL_TMP_PLATFORM"
 
         # Keep kernel tmp when building for a specific platform or when using keep tmp

--- a/build_shared.sh
+++ b/build_shared.sh
@@ -24,13 +24,6 @@ for platform in $PLATFORMS; do \
     if [ ! $only_build_for ] || [ $platform = $only_build_for ] ; then
 
         case $platform in
-            nagara)
-                COMPRESSED="false"
-                DTBO="true"
-                SOC=waipio
-                SOCDTB="waipio-v2.dtb"
-                DEVICES="pdx223 pdx224"
-                ;;
             columbia)
                 COMPRESSED="false"
                 DTBO="true"

--- a/build_shared_vars.sh
+++ b/build_shared_vars.sh
@@ -44,7 +44,7 @@ else
     ANDROID_ROOT="$ANDROID_BUILD_TOP"
 fi
 
-PLATFORMS="nagara"
+PLATFORMS="nagara columbia"
 
 # Mkdtimg tool
 MKDTIMG=$ANDROID_ROOT/out/host/linux-x86/bin/mkdtimg

--- a/build_shared_vars.sh
+++ b/build_shared_vars.sh
@@ -20,15 +20,17 @@ Usage: ${0##*/} [-k -p <platform>]
 Options:
 -k              keep kernel tmp after build
 -p <platform>   only build the kernel for <platform>
+-O <directory>  build kernel in <directory>
 EOF
 }
 
 
-arguments=khp:
+arguments=khp:O:
 while getopts $arguments argument ; do
     case $argument in
         k) keep_kernel_tmp=t ;;
         p) only_build_for=$OPTARG;;
+        O) build_directory=$OPTARG;;
         h) usage; exit 0;;
         ?) usage; exit 1;;
     esac
@@ -50,4 +52,4 @@ MKDTIMG=$ANDROID_ROOT/out/host/linux-x86/bin/mkdtimg
 KERNEL_TOP=$ANDROID_ROOT/kernel/sony/msm-5.10
 # $KERNEL_TMP sub dir per script
 c=${0##*-}
-KERNEL_TMP=$ANDROID_ROOT/out/kernel-5.10/${c%%.sh}
+KERNEL_TMP=${build_directory:-$ANDROID_ROOT/out/kernel-5.10/${c%%.sh}}

--- a/build_shared_vars.sh
+++ b/build_shared_vars.sh
@@ -44,7 +44,7 @@ else
     ANDROID_ROOT="$ANDROID_BUILD_TOP"
 fi
 
-PLATFORMS="nagara columbia"
+PLATFORMS="columbia"
 
 # Mkdtimg tool
 MKDTIMG=$ANDROID_ROOT/out/host/linux-x86/bin/mkdtimg


### PR DESCRIPTION
Add support for Columbia platform, PDX246 (Xperia 10 VI) device.

Sync scripts with 5.4 and 5.15 branches.

Remove Nagara platform, because it was ported to 5.15.