### PR TITLE
[1.0.r1] Refactor and modernize kernel build scripts

### DIFF
--- a/KernelConfig.mk
+++ b/KernelConfig.mk
@@ -22,7 +22,7 @@ ifeq ($(BOARD_INCLUDE_DTB_IN_BOOTIMG), true)
     # AOSP will concatenate all these into a single dtb.img
     BOARD_PREBUILT_DTBIMAGE_DIR := $(PLATFORM_KERNEL_OUT)/dtb/
 else
-    dtb := "-dtb"
+    dtb := -dtb
 endif
 
 ifeq ($(TARGET_NEEDS_DTBOIMAGE),true)

--- a/build-kernels-clang.sh
+++ b/build-kernels-clang.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 # Enable strict error handling:
-#   -e: immediate exit on error
 #   -u: error on unset vars
-set -eu
+#   -o pipefail: fail if any command in a pipeline fails
+# Note: We do NOT use -e because the script handles errors manually.
+set -uo pipefail
 
 # Handle Ctrl+C (SIGINT): print message and exit
 trap 'echo -e "\n${0##*/} execution was interrupted by Ctrl+C."; exit 1' SIGINT

--- a/build-kernels-clang.sh
+++ b/build-kernels-clang.sh
@@ -45,6 +45,7 @@ trap 'echo -e "\n${0##*/} execution was interrupted by Ctrl+C."; exit 1' SIGINT
 #   - Ensure that ANDROID_ROOT is defined before referencing toolchain paths.
 # -------------------------------------------------------------------------
 declare -A CLANG_VERSIONS=(
+    ['16']="$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r547379/bin/"
     ['15']="$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r522817/bin/"
     ['14']="$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r487747c/bin/"
     ['13']="$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r450784d/bin/"

--- a/build-kernels-clang.sh
+++ b/build-kernels-clang.sh
@@ -30,7 +30,8 @@ elif [ -d "$CLANG_A11" ]; then
 fi
 
 # Build command
-BUILD_ARGS="LLVM=1 LLVM_IAS=1 CC=clang"
+BUILD_ARGS="LLVM=1 LLVM_IAS=1 CC=clang \
+${verbose_output:+KCFLAGS='-fcolor-diagnostics'}"
 
 PATH=$CLANG:$PATH
 # source shared parts

--- a/build-kernels-clang.sh
+++ b/build-kernels-clang.sh
@@ -1,4 +1,12 @@
-#!/bin/sh
+#!/bin/bash
+
+# Enable strict error handling:
+#   -e: immediate exit on error
+#   -u: error on unset vars
+set -eu
+
+# Handle Ctrl+C (SIGINT): print message and exit
+trap 'echo -e "\n${0##*/} execution was interrupted by Ctrl+C."; exit 1' SIGINT
 
 . "${0%/*}/build_shared_vars.sh"
 

--- a/build-kernels-clang.sh
+++ b/build-kernels-clang.sh
@@ -49,8 +49,6 @@ declare -A CLANG_VERSIONS=(
     ['15']="$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r522817/bin/"
     ['14']="$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r487747c/bin/"
     ['13']="$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r450784d/bin/"
-    ['12']="$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r416183b/bin/"
-    ['11']="$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r353983c/bin/"
 )
 
 # Iterate through each version and return the first match

--- a/build-kernels-clang.sh
+++ b/build-kernels-clang.sh
@@ -11,23 +11,62 @@ trap 'echo -e "\n${0##*/} execution was interrupted by Ctrl+C."; exit 1' SIGINT
 
 . "${0%/*}/build_shared_vars.sh"
 
-CLANG_A11=$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r353983c/bin/
-CLANG_A12=$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r416183b/bin/
-CLANG_A13=$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r450784d/bin/
-CLANG_A14=$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r487747c/bin/
+# -------------------------------------------------------------------------
+# Associative Array: CLANG_VERSIONS
+# -------------------------------------------------------------------------
+# Description:
+#   CLANG_VERSIONS is a Bash associative array that maps each supported
+#   **Android version** to the Clang toolchain used to build that specific
+#   release within the AOSP build environment.
+#
+#   Each key represents an Android OS version (e.g., "16", "15", "14"),
+#   and the associated value provides the full path to the Clang
+#   toolchain's bin/ directory that matches the compiler used for that
+#   Android release.
+#
+# Ordering Requirement:
+#   - The **most recent Android version MUST appear first**.
+#   - Older Android versions must follow in strictly descending order.
+#   - When adding support for a new Android release, insert its entry at
+#     the beginning of the array to maintain correct ordering.
+#
+# Usage:
+#   To retrieve the Clang toolchain path for a given Android version:
+#
+#       clang_path="${CLANG_VERSIONS[$android_version]}"
+#
+#   Example:
+#       android_version="16"
+#       clang_path="${CLANG_VERSIONS[$android_version]}"
+#       echo "Using Clang for Android $android_version: $clang_path"
+#
+# Notes:
+#   - Keys represent Android version numbers, *not* LLVM/Clang major versions.
+#   - Ensure that ANDROID_ROOT is defined before referencing toolchain paths.
+# -------------------------------------------------------------------------
+declare -A CLANG_VERSIONS=(
+    ['14']="$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r487747c/bin/"
+    ['13']="$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r450784d/bin/"
+    ['12']="$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r416183b/bin/"
+    ['11']="$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r353983c/bin/"
+)
 
-if  [ -d "$CLANG_A14" ]; then
-    echo "Using Clang (build r487747c) from Android 14."
-    export CLANG=$CLANG_A14
-elif  [ -d "$CLANG_A13" ]; then
-    echo "Using Clang (build r450784d) from Android 13."
-    export CLANG=$CLANG_A13
-elif  [ -d "$CLANG_A12" ]; then
-    echo "Using Clang (build r416183b) from Android 12."
-    export CLANG=$CLANG_A12
-elif [ -d "$CLANG_A11" ]; then
-    echo "Using Clang (build r353983) from Android 11."
-    export CLANG=$CLANG_A11
+# Iterate through each version and return the first match
+for version in "${!CLANG_VERSIONS[@]}"; do
+    CLANG_PATH="${CLANG_VERSIONS[$version]}"
+    if [ -d "$CLANG_PATH" ]; then
+        BUILD_VERSION=$(basename "$(dirname "$CLANG_PATH")" | sed 's/clang-//')
+        echo "Using Clang (build $BUILD_VERSION) from Android $version."
+        CLANG="$CLANG_PATH"
+        break
+    fi
+done
+
+# Error check if no valid Clang path was found
+# This should never happen
+if [ -z "$CLANG" ]; then
+    echo "Error: No valid Clang path found. Please check your Android root."
+    exit 1
 fi
 
 # Build command

--- a/build-kernels-clang.sh
+++ b/build-kernels-clang.sh
@@ -45,6 +45,7 @@ trap 'echo -e "\n${0##*/} execution was interrupted by Ctrl+C."; exit 1' SIGINT
 #   - Ensure that ANDROID_ROOT is defined before referencing toolchain paths.
 # -------------------------------------------------------------------------
 declare -A CLANG_VERSIONS=(
+    ['15']="$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r522817/bin/"
     ['14']="$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r487747c/bin/"
     ['13']="$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r450784d/bin/"
     ['12']="$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r416183b/bin/"

--- a/build_shared.sh
+++ b/build_shared.sh
@@ -1,4 +1,3 @@
-set -e
 # Check if mkdtimg tool exist
 [ ! -f "$MKDTIMG" ] && MKDTIMG="$ANDROID_ROOT/prebuilts/misc/linux-x86/libufdt/mkdtimg"
 [ ! -f "$MKDTIMG" ] && MKDTIMG="$ANDROID_ROOT/system/libufdt/utils/src/mkdtboimg.py"
@@ -20,8 +19,7 @@ CROSS_COMPILE_ARM32=arm-linux-gnueabi- \
 -j$(nproc)"
 
 for platform in $PLATFORMS; do \
-
-    if [ ! $only_build_for ] || [ $platform = $only_build_for ] ; then
+    if [ -z "${only_build_for:-}" ] || [ "$platform" = "${only_build_for:-}" ]; then
 
         case $platform in
             columbia)
@@ -33,23 +31,24 @@ for platform in $PLATFORMS; do \
                 ;;
         esac
 
-        if [ "$COMPRESSED" = "true" ]; then
+        if [ "${COMPRESSED:-}" = "true" ]; then
             comp=".gz"
         fi
-        if [ ! "$SOCDTB" ]; then
+        if [ -z "${SOCDTB:-}" ]; then
             dtb="-dtb"
         fi
 
-        # Don't override $KERNEL_TMP when set by manually
-        if [ ! "$build_directory" ] ; then
-            KERNEL_TMP_PLATFORM=$KERNEL_TMP/${platform}
-        else
-            KERNEL_TMP_PLATFORM=${build_directory}
-        fi
-        BUILD_ARGS_PLATFORM="$BUILD_ARGS O=$KERNEL_TMP_PLATFORM"
+        # Set KERNEL_TMP_PLATFORM to either the value of build_directory (if set)
+        # or default to $KERNEL_TMP/${platform} if build_directory is unset or empty.
+        KERNEL_TMP_PLATFORM=${build_directory:-$KERNEL_TMP/${platform}}
+
+        # Construct the 'make' command with build arguments and specify the output
+        # directory for the kernel build. It is used for both loading the defconfig
+        # and performing the build process.
+        make_cmd="make $BUILD_ARGS O=$KERNEL_TMP_PLATFORM"
 
         # Keep kernel tmp when building for a specific platform or when using keep tmp
-        [ ! "$keep_kernel_tmp" ] && [ ! "$only_build_for" ] && rm -rf "${KERNEL_TMP_PLATFORM}"
+        [ "${keep_kernel_tmp:-}" != "true" ] && [ -z "${only_build_for:-}" ] && rm -rf "${KERNEL_TMP_PLATFORM}"
         mkdir -p "${KERNEL_TMP_PLATFORM}"
 
         PLATFORM_KERNEL_OUT=$KERNEL_TOP/common-kernel/$platform
@@ -61,22 +60,28 @@ for platform in $PLATFORMS; do \
 
         echo "================================================="
         echo "Platform -> ${platform}"
-        make $BUILD_ARGS_PLATFORM aosp_${platform}_defconfig
 
         echo "The build may take up to 10 minutes. Please be patient ..."
         echo "Building new kernel image ..."
         echo "Logging to $KERNEL_TMP_PLATFORM/build.log"
-        make $BUILD_ARGS_PLATFORM >"$KERNEL_TMP_PLATFORM/build.log" 2>&1;
+
+        # Load the defconfig.
+        $make_cmd aosp_${platform}_defconfig 2>&1;
+
+        # Run the build, log output.
+        $make_cmd > "$KERNEL_TMP_PLATFORM/build.log" 2>&1;
 
         echo "Copying new kernel image ..."
-        cp "$KERNEL_TMP_PLATFORM/arch/arm64/boot/Image$comp$dtb" "$PLATFORM_KERNEL_OUT/kernel$dtb"
+        cp "$KERNEL_TMP_PLATFORM/arch/arm64/boot/Image${comp:-}${dtb:-}" "$PLATFORM_KERNEL_OUT/kernel${dtb:-}"
 
-        if [ "$SOCDTB" ]; then
+        # If SOCDTB is specified, copy DTB files to the output directory.
+        if [ -n "${SOCDTB:-}" ]; then
             mkdir -p "$PLATFORM_KERNEL_OUT/dtb/"
             cp "$KERNEL_TMP_PLATFORM/arch/arm64/boot/dts/qcom/$SOCDTB" "$PLATFORM_KERNEL_OUT/dtb/"
         fi
 
-        if [ "$DTBO" = "true" ]; then
+        # If DTBO creation is enabled, generate DTBO files for each device.
+        if [ "${DTBO:-}" = "true" ]; then
             for device in $DEVICES; do
                 dtbo="$KERNEL_TMP_PLATFORM/arch/arm64/boot/dts/qcom/${SOC}-${platform}-${device}_generic-overlay.dtbo"
                 dtbo_out="$PLATFORM_KERNEL_OUT/dtbo-${device}.img"

--- a/build_shared.sh
+++ b/build_shared.sh
@@ -1,9 +1,3 @@
-# Check if mkdtimg tool exist
-[ ! -f "$MKDTIMG" ] && MKDTIMG="$ANDROID_ROOT/prebuilts/misc/linux-x86/libufdt/mkdtimg"
-[ ! -f "$MKDTIMG" ] && MKDTIMG="$ANDROID_ROOT/system/libufdt/utils/src/mkdtboimg.py"
-[ ! -f "$MKDTIMG" ] && (echo "No mkdtbo script/executable found"; exit 1)
-
-
 cd "$KERNEL_TOP"/kernel
 
 echo ""

--- a/build_shared.sh
+++ b/build_shared.sh
@@ -14,18 +14,14 @@ CROSS_COMPILE_ARM32=arm-linux-gnueabi- \
 -j$(nproc) \
 ${UFDT_APPLY_OVERLAY:+DTC_OVERLAY_TEST_EXT=$UFDT_APPLY_OVERLAY}"
 
-for platform in $PLATFORMS; do \
+for platform in "${!PLATFORMS[@]}"; do
     if [ -z "${only_build_for:-}" ] || [ "$platform" = "${only_build_for:-}" ]; then
-
-        case $platform in
-            columbia)
-                COMPRESSED="false"
-                DTBO="true"
-                SOC=parrot
-                SOCDTB="parrot.dtb"
-                DEVICES="pdx246"
-                ;;
-        esac
+        # Retrieve the platform configuration.
+        # TODO: Currently, there is no validation, and we rely on the assumption that
+        # the associative array contains no errors. This approach is not safe and could
+        # lead to issues if the array is malformed or contains unexpected data.
+        # Validation should be added to ensure data integrity.
+        eval ${PLATFORMS[$platform]}
 
         if [ "${COMPRESSED:-}" = "true" ]; then
             comp=".gz"

--- a/build_shared.sh
+++ b/build_shared.sh
@@ -94,6 +94,11 @@ for platform in $PLATFORMS; do \
                 check_error "Failed to create DTBO for device $device using $dtbo"
             done
         fi
+
+        # Normalize permissions. Set all files under $PLATFORM_KERNEL_OUT to 644.
+        # Some files, such as the kernel image, may be marked executable (755) by
+        # the build system.
+        find "$PLATFORM_KERNEL_OUT/" -type f | xargs chmod 644
     fi
 done
 

--- a/build_shared.sh
+++ b/build_shared.sh
@@ -6,6 +6,7 @@
 
 cd "$KERNEL_TOP"/kernel
 
+echo ""
 echo "================================================="
 echo "Your Environment:"
 echo "ANDROID_ROOT: ${ANDROID_ROOT}"
@@ -58,6 +59,10 @@ for platform in $PLATFORMS; do \
         # won't be erroneously copied from a build for a different platform
         find "$KERNEL_TMP_PLATFORM/arch/arm64/boot/dts/{qcom,somc}/" \( -name *.dtb -o -name *.dtbo \) -delete 2>/dev/null || true
 
+        # Truncate the log at the start of the build for a specific platform.
+        : > "$KERNEL_TMP_PLATFORM/build.log"
+
+        echo ""
         echo "================================================="
         echo "Platform -> ${platform}"
 
@@ -65,11 +70,11 @@ for platform in $PLATFORMS; do \
         echo "Building new kernel image ..."
         echo "Logging to $KERNEL_TMP_PLATFORM/build.log"
 
-        # Load the defconfig.
-        $make_cmd aosp_${platform}_defconfig 2>&1;
+        # Load the defconfig, log output.
+        $make_cmd aosp_${platform}_defconfig 2>&1 | log_pipeline
 
         # Run the build, log output.
-        $make_cmd > "$KERNEL_TMP_PLATFORM/build.log" 2>&1;
+        $make_cmd 2>&1 | log_pipeline
 
         echo "Copying new kernel image ..."
         cp "$KERNEL_TMP_PLATFORM/arch/arm64/boot/Image${comp:-}${dtb:-}" "$PLATFORM_KERNEL_OUT/kernel${dtb:-}"
@@ -92,6 +97,6 @@ for platform in $PLATFORMS; do \
     fi
 done
 
-
+echo ""
 echo "================================================="
 echo "Done!"

--- a/build_shared.sh
+++ b/build_shared.sh
@@ -70,19 +70,23 @@ for platform in $PLATFORMS; do \
         echo "Building new kernel image ..."
         echo "Logging to $KERNEL_TMP_PLATFORM/build.log"
 
-        # Load the defconfig, log output.
+        # Load the defconfig, log output, and check for errors.
         $make_cmd aosp_${platform}_defconfig 2>&1 | log_pipeline
+        check_error "Can't find aosp_${platform}_defconfig."
 
-        # Run the build, log output.
+        # Run the build, log output, and check for errors.
         $make_cmd 2>&1 | log_pipeline
+        check_error "Build failed. See $KERNEL_TMP_PLATFORM/build.log for details."
 
         echo "Copying new kernel image ..."
         cp "$KERNEL_TMP_PLATFORM/arch/arm64/boot/Image${comp:-}${dtb:-}" "$PLATFORM_KERNEL_OUT/kernel${dtb:-}"
+        check_error "Failed to copy kernel image to $PLATFORM_KERNEL_OUT/"
 
         # If SOCDTB is specified, copy DTB files to the output directory.
         if [ -n "${SOCDTB:-}" ]; then
             mkdir -p "$PLATFORM_KERNEL_OUT/dtb/"
             cp "$KERNEL_TMP_PLATFORM/arch/arm64/boot/dts/qcom/$SOCDTB" "$PLATFORM_KERNEL_OUT/dtb/"
+            check_error "Failed to copy $SOCDTB to $PLATFORM_KERNEL_OUT/dtb/"
         fi
 
         # If DTBO creation is enabled, generate DTBO files for each device.
@@ -92,6 +96,7 @@ for platform in $PLATFORMS; do \
                 dtbo_out="$PLATFORM_KERNEL_OUT/dtbo-${device}.img"
                 echo "Creating $dtbo_out ..."
                 $MKDTIMG create "$dtbo_out" $dtbo
+                check_error "Failed to create DTBO for device $device using $dtbo"
             done
         fi
     fi

--- a/build_shared.sh
+++ b/build_shared.sh
@@ -11,7 +11,8 @@ BUILD_ARGS="${BUILD_ARGS} \
 ARCH=arm64 \
 CROSS_COMPILE=aarch64-linux-gnu- \
 CROSS_COMPILE_ARM32=arm-linux-gnueabi- \
--j$(nproc)"
+-j$(nproc) \
+${UFDT_APPLY_OVERLAY:+DTC_OVERLAY_TEST_EXT=$UFDT_APPLY_OVERLAY}"
 
 for platform in $PLATFORMS; do \
     if [ -z "${only_build_for:-}" ] || [ "$platform" = "${only_build_for:-}" ]; then

--- a/build_shared_vars.sh
+++ b/build_shared_vars.sh
@@ -174,6 +174,14 @@ if [ ! -x "$MKDTIMG" ]; then
     exit 1
 fi
 
+# UFDT apply overlay tool. Optional
+# ufdt_apply_overlay verifies that the device tree overlay (DTO) can be applied to
+# the base device tree blob (DTB) without errors, ensuring correct configuration.
+UFDT_APPLY_OVERLAY=$ANDROID_ROOT/prebuilts/misc/linux-x86/libufdt/ufdt_apply_overlay
+if [ ! -x "$UFDT_APPLY_OVERLAY" ]; then
+    UFDT_APPLY_OVERLAY=""
+fi
+
 KERNEL_TOP=$ANDROID_ROOT/kernel/sony/msm-5.10
 # $KERNEL_TMP sub dir per script
 c=${0##*-}

--- a/build_shared_vars.sh
+++ b/build_shared_vars.sh
@@ -165,8 +165,6 @@ else
     ANDROID_ROOT="$ANDROID_BUILD_TOP"
 fi
 
-PLATFORMS="columbia"
-
 # Mkdtimg tool
 MKDTIMG=$ANDROID_ROOT/prebuilts/misc/linux-x86/libufdt/mkdtimg
 if [ ! -x "$MKDTIMG" ]; then
@@ -186,3 +184,46 @@ KERNEL_TOP=$ANDROID_ROOT/kernel/sony/msm-5.10
 # $KERNEL_TMP sub dir per script
 c=${0##*-}
 KERNEL_TMP=${build_directory:-$ANDROID_ROOT/out/kernel-5.10/${c%%.sh}}
+
+# -------------------------------------------------------------------------
+# Associative Array: PLATFORMS
+# -------------------------------------------------------------------------
+# Description:
+#   PLATFORMS is a Bash associative array that defines build-time
+#   configuration for each supported platform. Each key in the array is a
+#   platform name (e.g., "nagara", "yodo"), and the value is a multi-line
+#   string containing a set of variables required to build the kernel for
+#   that platform.
+#
+#   These variables may include:
+#     - COMPRESSED: Whether the kernel image should be compressed (true/false)
+#     - DTBO:       Whether a DTBO image should be generated (true/false)
+#     - SOC:        The SoC identifier used by the platform
+#     - SOCDTB:     The base SoC .dtb filename
+#     - DEVICES:    List of device identifiers belonging to the platform
+#
+# Usage:
+#   To load a platform’s configuration into the environment for use:
+#
+#       eval "${PLATFORMS[$platform_name]}"
+#
+#   Example:
+#       platform="yodo"
+#       eval "${PLATFORMS[$platform]}"
+#       echo "Building for SoC: $SOC"
+#
+# Notes:
+#   - Values are stored as plain multi-line strings. `eval` is required to
+#     turn them into variables in the current environment.
+#   - New platforms can be added by extending the PLATFORMS array with a new
+#     key and its configuration block.
+# -------------------------------------------------------------------------
+declare -A PLATFORMS=(
+    ['columbia']="
+        COMPRESSED=false
+        DTBO=true
+        SOC='parrot'
+        SOCDTB='parrot.dtb'
+        DEVICES='pdx246'
+    "
+)

--- a/build_shared_vars.sh
+++ b/build_shared_vars.sh
@@ -1,35 +1,115 @@
-find_repo_root()
-# desc: Find root of a repo tree and echo it
-{
-    (
-        max_depth=10
-        while ! [ -e "$PWD/.repo" ] ; do
-            [ $max_depth -eq 0 ] && return 1
-            cd ..
-            max_depth=$((max_depth-1))
-        done
-        echo "$PWD"
-    )
+# -------------------------------------------------------------------------
+# Function: find_repo_root
+# -------------------------------------------------------------------------
+# Description:
+# This function searches for the root of a repository by looking for the
+# presence of a `.repo` directory. It starts in the current working
+# directory and moves upwards through the directory tree, stopping when
+# the root is found or a maximum depth of 10 is reached.
+
+# Usage:
+#   find_repo_root
+
+# Returns:
+#   - Prints the directory path where `.repo` is found (repository root).
+#   - Exits with status code 1 if `.repo` is not found within the allowed
+#     depth.
+
+# Parameters:
+#   None
+
+# Example:
+#   repo_root=$(find_repo_root)
+#   echo "Repository root is: $repo_root"
+# -------------------------------------------------------------------------
+find_repo_root() {
+    local max_depth=10
+    while ! [ -e "$PWD/.repo" ] ; do
+        [ $max_depth -eq 0 ] && return 1
+        cd ..
+        max_depth=$((max_depth-1))
+    done
+    echo "$PWD"
 }
 
-usage(){
+# -------------------------------------------------------------------------
+# Function: log_pipeline
+# -------------------------------------------------------------------------
+# Description:
+# This function logs the output of a pipeline to a log file.
+# It optionally strips ANSI escape codes from the output (like terminal
+# colors). If the `verbose_output` variable is set, it will also display
+# the output on the screen while logging it.
+
+# Usage:
+#   log_pipeline [destination]
+
+# Returns:
+#   - Writes the output of a pipeline (with optional ANSI escape code
+#     removal) to the specified destination file or the default
+#     `$KERNEL_TMP_PLATFORM/build.log`.
+
+# Parameters:
+#   - destination: Optional argument specifying the log file destination.
+
+# Example:
+#   make | log_pipeline /path/to/logfile.log
+# -------------------------------------------------------------------------
+log_pipeline() {
+    # Use the argument or fallback to the default log path
+    local dest="${1:-$KERNEL_TMP_PLATFORM/build.log}"
+    local strip_ansi='s/\x1B\[[0-9;]*[mK]//g'
+
+    # Remove ANSI escape codes
+    if [ -n "${verbose_output:-}" ]; then
+        tee >(sed -E "$strip_ansi" >>"$dest")
+    else
+        sed -E "$strip_ansi" >>"$dest"
+    fi
+}
+
+# -------------------------------------------------------------------------
+# Function: usage
+# -------------------------------------------------------------------------
+# Description:
+# This function displays the usage information for the script. It provides
+# a summary of available command-line options and their descriptions.
+# It's typically invoked when the user requests help (`-h` option) or when
+# incorrect arguments are passed.
+
+# Usage:
+#   usage
+
+# Returns:
+#   - Prints the usage information to standard output and exits the script
+#     with status code 0.
+
+# Parameters:
+#   None
+
+# Example:
+#   ./build-kernels-clang.sh -h  # Will display the usage information.
+# -------------------------------------------------------------------------
+usage() {
     cat <<EOF
 Build kernel for supported devices
-Usage: ${0##*/} [-k -p <platform>]
+Usage: ${0##*/} [-k -h -p <platform> -v -O <directory>]
 
 Options:
--k              keep kernel tmp after build
--p <platform>   only build the kernel for <platform>
--O <directory>  build kernel in <directory>
+  -k              keep kernel tmp after build
+  -h              show help message and exit
+  -p <platform>   only build the kernel for <platform>
+  -v              enable verbose output
+  -O <directory>  build kernel in <directory>
 EOF
 }
 
-
-arguments=khp:O:
+arguments=khp:vO:
 while getopts $arguments argument ; do
     case $argument in
         k) keep_kernel_tmp=true ;;
         p) only_build_for=$OPTARG;;
+        v) verbose_output=true ;;
         O) build_directory=$OPTARG;;
         h) usage; exit 0;;
         ?) usage; exit 1;;

--- a/build_shared_vars.sh
+++ b/build_shared_vars.sh
@@ -1,4 +1,44 @@
 # -------------------------------------------------------------------------
+# Function: check_error
+# -------------------------------------------------------------------------
+# Description:
+# This function checks the exit status of the last executed command. If the
+# command failed (non-zero exit status), it prints an error message in red
+# and exits the script with a status code of `1`. If the last command was
+# part of a pipeline, the first command in the pipeline is checked.
+
+# Usage:
+#   check_error "Custom error message"
+
+# Returns:
+#   - Prints an error message if the last command failed and exits
+#     with status code `1`.
+#   - Does nothing if the last command was successful.
+
+# Parameters:
+#   - $1 (optional): A custom error message. If not provided, the default
+#     message `"Command failed"` is used.
+
+# Example:
+#   some_command
+#   check_error "Failed to execute some_command"
+# -------------------------------------------------------------------------
+check_error() {
+    local exit_code=$?
+    local message=${1:-"Command failed"}
+
+    # If PIPESTATUS exists and has more than 1 element, we are in a pipeline
+    if [ "${#PIPESTATUS[@]}" -gt 1 ]; then
+        exit_code=${PIPESTATUS[0]}
+    fi
+
+    if [ "$exit_code" -ne 0 ]; then
+        echo -e "\e[1;31mError:\e[0m $message" >&2
+        exit 1
+    fi
+}
+
+# -------------------------------------------------------------------------
 # Function: find_repo_root
 # -------------------------------------------------------------------------
 # Description:
@@ -118,6 +158,7 @@ done
 
 if [ -z "${ANDROID_BUILD_TOP:-}" ]; then
     ANDROID_ROOT=$(find_repo_root)
+    check_error "Unable to find the repository root folder. Please check your Android root."
     ANDROID_ROOT=$(realpath "$ANDROID_ROOT")
     echo "ANDROID_BUILD_TOP not set, guessing root at $ANDROID_ROOT"
 else

--- a/build_shared_vars.sh
+++ b/build_shared_vars.sh
@@ -28,7 +28,7 @@ EOF
 arguments=khp:O:
 while getopts $arguments argument ; do
     case $argument in
-        k) keep_kernel_tmp=t ;;
+        k) keep_kernel_tmp=true ;;
         p) only_build_for=$OPTARG;;
         O) build_directory=$OPTARG;;
         h) usage; exit 0;;
@@ -36,7 +36,7 @@ while getopts $arguments argument ; do
     esac
 done
 
-if [ -z "$ANDROID_BUILD_TOP" ]; then
+if [ -z "${ANDROID_BUILD_TOP:-}" ]; then
     ANDROID_ROOT=$(find_repo_root)
     ANDROID_ROOT=$(realpath "$ANDROID_ROOT")
     echo "ANDROID_BUILD_TOP not set, guessing root at $ANDROID_ROOT"

--- a/build_shared_vars.sh
+++ b/build_shared_vars.sh
@@ -168,7 +168,11 @@ fi
 PLATFORMS="columbia"
 
 # Mkdtimg tool
-MKDTIMG=$ANDROID_ROOT/out/host/linux-x86/bin/mkdtimg
+MKDTIMG=$ANDROID_ROOT/prebuilts/misc/linux-x86/libufdt/mkdtimg
+if [ ! -x "$MKDTIMG" ]; then
+    echo "Error: No mkdtbo executable found. Please check your Android root."
+    exit 1
+fi
 
 KERNEL_TOP=$ANDROID_ROOT/kernel/sony/msm-5.10
 # $KERNEL_TMP sub dir per script


### PR DESCRIPTION
This pull request introduces multiple improvements across the kernel build scripts, focusing on modernizing Clang selection, platform configuration, build robustness, logging, and compatibility with recent Android releases.

**Key changes:**

**1. Clang toolchain management**
- Removed old Clang versions associated with Android 12, which has reached EOL and is no longer supported for security reasons.
- Added Clang versions for Android 15 (`clang-r522817`) and Android 16 (`clang-r547379`) to support newer releases.
- Refactored Clang selection in `build-kernels-clang.sh` to use a Bash associative array (`CLANG_VERSIONS`) instead of chained if statements.
- Automatically selects the latest available toolchain.
- Simplifies adding new Android versions.
- Centralized, self-documenting, and easier to maintain.

**2. Platform configuration improvements**

- Migrated platform-specific kernel build settings to a Bash associative array (`PLATFORMS`) from the previous case-based approach.
- Each platform now has a centralized configuration with variables like `COMPRESSED`, `DTBO`, `SOC`, `SOCDTB`, and `DEVICES`.
- Simplifies addition of new platforms and improves readability.

**3. Build reliability and safety**

- Introduced a `check_error` function for strict error handling across all build scripts.
- Ensures failures are detected immediately and reported clearly.
- Replaces `set -eu` with `set -uo pipefail` for safer pipeline handling.
- Improved handling of unset variables and centralized build commands using `make_cmd`.
- Added a `SIGINT` trap for safe interruption of builds.
- Normalized permissions of all output files to 644 to prevent accidental executables.

**4. Device Tree and DTBO handling**
- Use `ufdt_apply_overlay` to verify that device tree overlays (DTOs) are valid before build completion, avoiding runtime boot issues.
- Always use the prebuilt `mkdtimg` tool included with AOSP, simplifying DTBO creation.

**5. Logging and verbosity**
- Added support for verbose output with syntax-highlighted Clang errors in the terminal while logging clean output to file.
- Introduced a `log_pipeline` function to handle ANSI escape codes correctly in logs.
- Updated `usage` help text to include `-v` (verbose) option.

**Impact:**
These changes make the kernel build scripts cleaner, safer, and easier to extend, while ensuring compatibility with the latest Android versions and modern development practices.

**PS:** I probably over-documented everything, but I hope this will make it easier for others to understand how all parts of the build system work.